### PR TITLE
初期読み込み時に、NGワードリストのURLをwindow.promptで指定させる

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.9.3
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directories
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,295 @@
+{
+  "name": "zendesk-incident-protector",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.5"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.8.4.tgz",
+      "integrity": "sha1-wiZl8eDRucPF4bCNq9HxCGleT88=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.5"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "dev": true,
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "mock-local-storage": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mock-local-storage/-/mock-local-storage-1.0.5.tgz",
+      "integrity": "sha1-iZ/zAAJ87+1HgW5txTm7BZ/M5Ik=",
+      "dev": true,
+      "requires": {
+        "core-js": "0.8.4",
+        "global": "4.3.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "zendesk-incident-protector",
+  "version": "1.0.0",
+  "description": "Prevent replying to customer with specific NG keywords",
+  "main": "zendesk-incident-protector.user.js",
+  "scripts": {
+    "test": "$(npm bin)/mocha './test/zendesk-incident-protector.spec.js'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hashijun/zendesk-incident-protector.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/hashijun/zendesk-incident-protector/issues"
+  },
+  "homepage": "https://github.com/hashijun/zendesk-incident-protector#readme",
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^4.0.1",
+    "mock-local-storage": "^1.0.5"
+  }
+}

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -1,0 +1,75 @@
+let chai         = require('chai');
+let path         = require('path');
+let localStorage = require('mock-local-storage');
+let should       = chai.should();
+
+let NGWordManager = require(path.join(__dirname, '..', 'zendesk-incident-protector.user.js'));
+
+// define window after require user.js
+global.window = {};
+window.localStorage = global.localStorage;
+
+describe('NGWordManager', () => {
+  const localStorageKey = 'testLocalStorageKey';
+  let ngWordManager;
+
+  beforeEach(() => {
+    ngWordManager = new NGWordManager(localStorageKey);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    window.localStorage.itemInsertionCallback = null;
+  });
+
+  describe('#isConfigURLEmpty', () => {
+    context('localStorage is empty', () => {
+      it('should return true', () => {
+        ngWordManager.isConfigURLEmpty().should.equal(true);
+      });
+    });
+    context('localStorage exists', () => {
+      before(() => {
+        window.localStorage.setItem(localStorageKey, 'https://path/to/config.json');
+      });
+
+      it('should return false', () => {
+        ngWordManager.isConfigURLEmpty().should.equal(false);
+      });
+    });
+  });
+
+  describe('#setConfigURL', () => {
+    context('arg is URL', () => {
+      it('should set arg to localStorage', () => {
+        let arg = 'https://path/to/config.json';
+
+        ngWordManager.setConfigURL(arg);
+        window.localStorage.getItem(localStorageKey).should.equal(arg);
+      });
+    });
+
+    context('arg is not URL', () => {
+      it('does not set localStorage', () => {
+        let arg = 'not url';
+
+        ngWordManager.setConfigURL(arg);
+        should.equal(window.localStorage.getItem(localStorageKey), null);
+      });
+    });
+  });
+
+  describe('#isValidConfigURL', () => {
+    context('arg is URL', () => {
+      it('should return true', () => {
+        ngWordManager.isValidConfigURL('https://path/to/config.json').should.equal(true);
+      });
+    });
+
+    context('arg is not URL', () => {
+      it('should return false', () => {
+        ngWordManager.isValidConfigURL('not url').should.equal(false);
+      });
+    });
+  });
+});

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -5,6 +5,18 @@ let should       = chai.should();
 
 let NGWordManager = require(path.join(__dirname, '..', 'zendesk-incident-protector.user.js'));
 
+// mock URL class
+class URL {
+  constructor(arg) {
+    if (arg.includes('http')) {
+      return {};
+    } else {
+      throw new TypeError('URL');
+    }
+  }
+}
+global.URL = URL;
+
 // define window after require user.js
 global.window = {};
 window.localStorage = global.localStorage;

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -38,9 +38,6 @@
   // execute UserScript on browser, and export NGWordManager class on test
   if (typeof window === 'object') {
     const localStorageKey = 'zendeskIncidentProtectorConfigURL';
-    const isEmpty = (arg) => {
-      return arg === null || arg === undefined;
-    };
 
     let ngWordManager = new NGWordManager(localStorageKey);
     let runUserScript = () => {

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -26,8 +26,12 @@
       }
     }
     isValidConfigURL(arg) {
-      let urlRegExp = new RegExp('^(https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)$');
-      return arg.match(urlRegExp) !== null;
+      try {
+        let url = new URL(arg);
+        return true;
+      } catch (e) {
+        return false;
+      }
     }
   }
 

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -1,0 +1,12 @@
+// ==UserScript==
+// @name           Zendesk Incident Protector
+// @version        1.0.0
+// @description    Prevent replying to customer with specific NG keywords
+// @author         XFLAG Studio CRE Team
+// @include        https://*.zendesk.com/*
+// @exclude        https://*.zendesk.com/knowledge/*
+// @require        https://code.jquery.com/jquery-3.2.1.min.js
+// ==/UserScript==
+
+(function() {
+})();

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -9,4 +9,46 @@
 // ==/UserScript==
 
 (function() {
+  'use strict';
+
+  class NGWordManager {
+    constructor(localStorageKey) {
+      this.localStorageKey = localStorageKey;
+    }
+
+    isConfigURLEmpty() {
+      let configURL = localStorage.getItem(this.localStorageKey);
+      return configURL === null;
+    }
+    setConfigURL(arg) {
+      if (this.isValidConfigURL(arg)) {
+        localStorage.setItem(this.localStorageKey, arg);
+      }
+    }
+    isValidConfigURL(arg) {
+      let urlRegExp = new RegExp('^(https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)$');
+      return arg.match(urlRegExp) !== null;
+    }
+  }
+
+  // execute UserScript on browser, and export NGWordManager class on test
+  if (typeof window === 'object') {
+    const localStorageKey = 'zendeskIncidentProtectorConfigURL';
+    const isEmpty = (arg) => {
+      return arg === null || arg === undefined;
+    };
+
+    let ngWordManager = new NGWordManager(localStorageKey);
+    let runUserScript = () => {
+      if (ngWordManager.isConfigURLEmpty()) {
+        let configURL = window.prompt('[Zendesk 事故防止ツール]\nNGワードの設定が記載されたURLを指定してください', '');
+
+        ngWordManager.setConfigURL(configURL);
+      }
+    };
+
+    runUserScript();
+  } else {
+    module.exports = NGWordManager;
+  }
 })();


### PR DESCRIPTION
ユーザースクリプトを組み込み後にZendeskページを表示した際に、NGワードの定義されたURLを `window.prompt` で入力させ、入力内容を `localStorage` で保持するようにしました。

`localStorage` にセットされている場合は、パブリック返信のクリックイベントでNGワードを元に必要であればアラートを表示する、という流れで今後の実装を続けていきます。

**画面イメージ**

![image](https://user-images.githubusercontent.com/5433425/34282889-282d9164-e70c-11e7-8040-0df3e5b117cf.png)
