### PR TITLE
タブごとにValidatorを仕込んでいるかどうかを管理するclassを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -407,6 +407,15 @@
         "mime-types": "2.1.17"
       }
     },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "formidable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
@@ -645,6 +654,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "left-pad": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
@@ -667,10 +682,22 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
       "dev": true
     },
     "methods": {
@@ -734,9 +761,9 @@
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -766,6 +793,27 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        }
+      }
     },
     "nock": {
       "version": "9.1.6",
@@ -878,6 +926,23 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -1004,6 +1069,12 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -1015,6 +1086,32 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.1.tgz",
+      "integrity": "sha512-lx9ZCoScNhvs6+n3ku78CqIpQNIiY9gLfvuIdhZjnKOkcVL6FfWfA1jkOrcO+n3mX4BIg2XwQnyCS/Ive21QMw==",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.5"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "sntp": {
       "version": "2.1.0",
@@ -1100,6 +1197,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
   "homepage": "https://github.com/hashijun/zendesk-incident-protector#readme",
   "devDependencies": {
     "chai": "^4.1.2",
-    "mocha": "^4.0.1",
-    "mock-local-storage": "^1.0.5",
-    "superagent": "^3.8.2",
-    "nock": "^9.1.6",
     "jquery": "^3.2.1",
-    "jsdom": "^11.5.1"
-  }
+    "jsdom": "^11.5.1",
+    "mocha": "^4.1.0",
+    "mock-local-storage": "^1.0.5",
+    "nock": "^9.1.6",
+    "sinon": "^4.2.1",
+    "superagent": "^3.8.2"
+  },
+  "dependencies": {}
 }

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -7,7 +7,9 @@ let assert       = require('assert');
 let jsdom        = require('jsdom');
 let should       = chai.should();
 
-let NGWordManager = require(path.join(__dirname, '..', 'zendesk-incident-protector.user.js'));
+let exportedClass = require(path.join(__dirname, '..', 'zendesk-incident-protector.user.js'));
+let NGWordManager = exportedClass.NGWordManager;
+
 const { JSDOM } = jsdom;
 const defaultDOM = new JSDOM(`
 <!-- comment textarea -->

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -192,13 +192,15 @@ describe('NGWordManager', () => {
     });
   });
   describe('isTargetHost', () => {
-    let config = mockConfig;
+    beforeEach(() => {
+      ngWordManager.config = mockConfig;
+    });
 
     context('host defined in config', () => {
       let host = 'aaa.zendesk.com';
 
       it('returns true', () => {
-        ngWordManager.isTargetHost(config, host).should.equal(true);
+        ngWordManager.isTargetHost(host).should.equal(true);
       });
     });
 
@@ -206,13 +208,15 @@ describe('NGWordManager', () => {
       let host = 'unknown.zendesk.com';
 
       it('returns false', () => {
-        ngWordManager.isTargetHost(config, host).should.equal(false);
+        ngWordManager.isTargetHost(host).should.equal(false);
       });
     });
   });
 
   describe('isIncludeTargetWord', () => {
-    let config = mockConfig;
+    beforeEach(() => {
+      ngWordManager.config = mockConfig;
+    });
 
     // text with word in common target words
     let text1 = 'test hogehoge';
@@ -225,9 +229,9 @@ describe('NGWordManager', () => {
       it('judges target words defined on common and host', () => {
         let host = 'aaa.zendesk.com';
 
-        ngWordManager.isIncludeTargetWord(mockConfig, text1, host).should.equal(true);
-        ngWordManager.isIncludeTargetWord(mockConfig, text2, host).should.equal(true);
-        ngWordManager.isIncludeTargetWord(mockConfig, text3, host).should.equal(false);
+        ngWordManager.isIncludeTargetWord(text1, host).should.equal(true);
+        ngWordManager.isIncludeTargetWord(text2, host).should.equal(true);
+        ngWordManager.isIncludeTargetWord(text3, host).should.equal(false);
       });
     });
 
@@ -235,9 +239,9 @@ describe('NGWordManager', () => {
       it('judges target words defined on common', () => {
         let host = 'ddd.zendesk.com';
 
-        ngWordManager.isIncludeTargetWord(mockConfig, text1, host).should.equal(true);
-        ngWordManager.isIncludeTargetWord(mockConfig, text2, host).should.equal(false);
-        ngWordManager.isIncludeTargetWord(mockConfig, text3, host).should.equal(false);
+        ngWordManager.isIncludeTargetWord(text1, host).should.equal(true);
+        ngWordManager.isIncludeTargetWord(text2, host).should.equal(false);
+        ngWordManager.isIncludeTargetWord(text3, host).should.equal(false);
       });
     });
   });

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -59,6 +59,26 @@
         }
       };
     }
+
+    getButtonId() {
+      let submitButton = $(ValidatorManager.UI_CONSTANTS.selector.submitButton).filter(':visible');
+      return submitButton.parent().attr('id');
+    }
+
+    addValidator() {
+      let buttonId = this.getButtonId();
+      if (buttonId !== undefined && !this.hasValidator(buttonId)) {
+        this.idsWithValidator.push(buttonId);
+        console.log('button id added. id:' + buttonId + ' idsWithValidator:' + this.idsWithValidator);
+
+        // TODO: add code
+        // new NGWordValidator(buttonId);
+      }
+    }
+
+    hasValidator(id) {
+      return this.idsWithValidator.includes(id);
+    }
   }
 
   class NGWordManager {
@@ -168,6 +188,7 @@
           ).then(
             (object) => {
               console.log('submit button loaded!');
+              validatorManager.addValidator();
             }
           ).catch(
             (error) => { alert(error.message); }

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -199,6 +199,7 @@
     runUserScript();
   } else {
     module.exports = {
+      ValidatorManager: ValidatorManager,
       NGWordManager: NGWordManager
     };
   }

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -43,6 +43,24 @@
     });
   }
 
+  // NOTE:
+  // Zendesk dashboard can show multiple tickets by separating tabs.
+  // This class manages whether to set validator or not with each tabs
+  // by recording id attribute of div tag on submit button.
+  class ValidatorManager {
+    constructor() {
+      this.idsWithValidator = [];
+    }
+
+    static get UI_CONSTANTS() {
+      return {
+        selector: {
+          submitButton: 'footer.ticket-resolution-footer div.ticket-resolution-footer-pane div.ticket_submit_buttons button'
+        }
+      };
+    }
+  }
+
   class NGWordManager {
     constructor(localStorageKey) {
       this.localStorageKey = localStorageKey;
@@ -131,7 +149,9 @@
   if (typeof window === 'object') {
     const localStorageKey = 'zendeskIncidentProtectorConfigURL';
 
-    let ngWordManager = new NGWordManager(localStorageKey);
+    let ngWordManager    = new NGWordManager(localStorageKey);
+    let validatorManager = new ValidatorManager();
+
     let runUserScript = () => {
       if (ngWordManager.isConfigURLEmpty()) {
         let configURL = window.prompt('[Zendesk 事故防止ツール]\nNGワードの設定が記載されたURLを指定してください', '');

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -113,6 +113,8 @@
 
     runUserScript();
   } else {
-    module.exports = NGWordManager;
+    module.exports = {
+      NGWordManager: NGWordManager
+    };
   }
 })();

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -106,12 +106,12 @@
 
       return !commentActionTarget ? false : commentActionTarget.includes(publicCommentClass);
     }
-    isTargetHost(config, host) {
-      return config.hosts.includes(host);
+    isTargetHost(host) {
+      return this.config.hosts.includes(host);
     }
-    isIncludeTargetWord(config, text, host) {
-      let commonTargetWords = config.targetWords.common;
-      let targetWords       = config.targetWords[host];
+    isIncludeTargetWord(text, host) {
+      let commonTargetWords = this.config.targetWords.common;
+      let targetWords       = this.config.targetWords[host];
 
       let allTargetWords = Array.isArray(targetWords) ? commonTargetWords.concat(targetWords) : commonTargetWords;
 

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -33,7 +33,7 @@
           tryCheck(resolve, reject);
         }, loopTime);
       } else {
-        reject(new Error('Not found element match the selector:' + selector));
+        reject(new Error(`Not found element match the selector:${selector}`));
       }
       tryCount++;
     }
@@ -69,7 +69,7 @@
       let buttonId = this.getButtonId();
       if (buttonId !== undefined && !this.hasValidator(buttonId)) {
         this.idsWithValidator.push(buttonId);
-        console.log('button id added. id:' + buttonId + ' idsWithValidator:' + this.idsWithValidator);
+        console.log(`button id added. id:${buttonId} idsWithValidator:${this.idsWithValidator}`);
 
         // TODO: add code
         // new NGWordValidator(buttonId);

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -61,6 +61,14 @@
       };
     }
 
+    get config() {
+      return this._config;
+    }
+
+    set config(arg) {
+      this._config = arg;
+    }
+
     isConfigURLEmpty() {
       let configURL = localStorage.getItem(this.localStorageKey);
       return configURL === null;
@@ -133,7 +141,7 @@
         ngWordManager.fetchConfig()
           .then(
             (object) => {
-              // ngWordManager.startValidation();
+              ngWordManager.config = object;
             }
           ).catch(
             (error) => { alert(error.message); }

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -162,6 +162,12 @@
           .then(
             (object) => {
               ngWordManager.config = object;
+
+              return waitForElement(ValidatorManager.UI_CONSTANTS.selector.submitButton);
+            }
+          ).then(
+            (object) => {
+              console.log('submit button loaded!');
             }
           ).catch(
             (error) => { alert(error.message); }

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -13,6 +13,36 @@
 (function() {
   'use strict';
 
+  // TODO:
+  // fix to use CDN
+  // Add minified script to https://github.com/azu/wait-for-element.js
+  function waitForElement(selector) {
+    const timeout    = 10 * 1000; // 10s
+    const loopTime   = 100;
+    const limitCount = timeout / loopTime;
+
+    let tryCount = 0;
+
+    function tryCheck(resolve, reject) {
+      if (tryCount < limitCount) {
+        var element = document.querySelector(selector);
+        if (element != null) {
+          return resolve(element);
+        }
+        setTimeout(function () {
+          tryCheck(resolve, reject);
+        }, loopTime);
+      } else {
+        reject(new Error('Not found element match the selector:' + selector));
+      }
+      tryCount++;
+    }
+
+    return new Promise(function (resolve, reject) {
+      tryCheck(resolve, reject);
+    });
+  }
+
   class NGWordManager {
     constructor(localStorageKey) {
       this.localStorageKey = localStorageKey;

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -69,7 +69,7 @@
       return !commentActionTarget ? false : commentActionTarget.includes(publicCommentClass);
     }
     isTargetHost(config, host) {
-      return config.hosts.includes(host)
+      return config.hosts.includes(host);
     }
     isIncludeTargetWord(config, text, host) {
       let commonTargetWords = config.targetWords.common;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5433425/35377376-4eca4d98-01f2-11e8-98bd-332da9617043.png)

Zendeskは1つの画面内に複数のタブを表示することが出来るようになっており、これらのタブそれぞれに投稿画面や送信画面があります。

そのため、NGワードが含まれているかどうかを検証するValidatorを各タブごとに仕込む必要があります。

このPRでは、どのタブにValidatorを仕込んだかを管理する `ValidatorManager` クラスを実装します。実際にvalidatorを追加する処理は後のPRで実装予定です。