### PR TITLE
ValidatorManager#addValidatorを実行時にvalidatorを仕込む

### DIFF
--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -86,7 +86,9 @@ describe('ValidatorManager', () => {
 
   describe('addValidator', () => {
     it('adds button id into idsWithValidator', () => {
-      validatorManager.addValidator();
+      const targetWords = ['test', 'memo', '(aaa|xxx)'];
+
+      validatorManager.addValidator(targetWords);
       validatorManager.idsWithValidator.should.contain(expectedButtonId);
     });
   });

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -88,7 +88,9 @@ describe('ValidatorManager', () => {
     it('adds button id into idsWithValidator', () => {
       const targetWords = ['test', 'memo', '(aaa|xxx)'];
 
-      validatorManager.addValidator(targetWords);
+      let validator = validatorManager.addValidator(targetWords);
+
+      (validator instanceof NGWordValidator).should.equal(true);
       validatorManager.idsWithValidator.should.contain(expectedButtonId);
     });
   });

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -241,6 +241,30 @@ describe('NGWordManager', () => {
           }).catch(done);
       });
     });
+
+    describe('toTargetWords', () => {
+      beforeEach(() => {
+        ngWordManager.config = mockConfig;
+      });
+
+      context('target words at host is defined', () => {
+        it('returns target words defined on common and host', () => {
+          let host = 'aaa.zendesk.com';
+          let expected = ['test', 'memo', '(aaa|xxx)'];
+
+          ngWordManager.toTargetWords(host).should.eql(expected);
+        });
+      });
+
+      context('target words at host is not defined', () => {
+        it('returns target words defined on common', () => {
+          let host = 'ddd.zendesk.com';
+          let expected = ['test', 'memo'];
+
+          ngWordManager.toTargetWords(host).should.eql(expected);
+        });
+      });
+    });
   });
 
   describe('isTargetHost', () => {

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -242,24 +242,6 @@ describe('NGWordManager', () => {
     });
   });
 
-  describe('isPublicResponse', () => {
-    context('tab of public response has been selected', () => {
-      it('returns true', () => {
-        ngWordManager.isPublicResponse().should.equal(true);
-      });
-    });
-
-    context('tab of private response has been selected', () => {
-      before(() => {
-        $('span.track-id-publicComment').removeClass('active');
-        $('span.track-id-privateComment').addClass('active');
-      });
-
-      it('returns false', () => {
-        ngWordManager.isPublicResponse().should.equal(false);
-      });
-    });
-  });
   describe('isTargetHost', () => {
     beforeEach(() => {
       ngWordManager.config = mockConfig;
@@ -279,50 +261,6 @@ describe('NGWordManager', () => {
       it('returns false', () => {
         ngWordManager.isTargetHost(host).should.equal(false);
       });
-    });
-  });
-
-  describe('isIncludeTargetWord', () => {
-    beforeEach(() => {
-      ngWordManager.config = mockConfig;
-    });
-
-    // text with word in common target words
-    let text1 = 'test hogehoge';
-    // text with word in target words of aaa.zendesk.com
-    let text2 = '(aaa|xxx) hogehoge';
-    // text without target words
-    let text3 = 'aaa hogehoge';
-
-    context('target words at host is defined', () => {
-      it('judges target words defined on common and host', () => {
-        let host = 'aaa.zendesk.com';
-
-        ngWordManager.isIncludeTargetWord(text1, host).should.equal(true);
-        ngWordManager.isIncludeTargetWord(text2, host).should.equal(true);
-        ngWordManager.isIncludeTargetWord(text3, host).should.equal(false);
-      });
-    });
-
-    context('target words at host is not defined', () => {
-      it('judges target words defined on common', () => {
-        let host = 'ddd.zendesk.com';
-
-        ngWordManager.isIncludeTargetWord(text1, host).should.equal(true);
-        ngWordManager.isIncludeTargetWord(text2, host).should.equal(false);
-        ngWordManager.isIncludeTargetWord(text3, host).should.equal(false);
-      });
-    });
-  });
-
-  describe('createConfirmText', () => {
-    let text = $(NGWordManager.UI_CONSTANTS.selector.commentTextArea).html();
-    let expectedText = 'testmessage';
-
-    it('returns confirm text', () => {
-      let confirmText = ngWordManager.createConfirmText(text);
-
-      confirmText.includes(expectedText).should.equal(true);
     });
   });
 });

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -87,18 +87,6 @@
       this.request         = window.superagent;
     }
 
-    static get UI_CONSTANTS() {
-      return {
-        selector: {
-          commentActionTarget: 'div.comment_input_wrapper div.fr-focus div.content div.header span.active',
-          commentTextArea: 'div.comment_input_wrapper div.fr-focus div.content div.body div.ember-view div.editor div.zendesk-editor--rich-text-comment'
-        },
-        attribute: {
-          publicCommentClass: 'track-id-publicComment'
-        }
-      };
-    }
-
     get config() {
       return this._config;
     }
@@ -138,30 +126,8 @@
           });
       });
     }
-    isPublicResponse() {
-      let publicCommentClass  = NGWordManager.UI_CONSTANTS.attribute.publicCommentClass;
-      let commentActionTarget = $(NGWordManager.UI_CONSTANTS.selector.commentActionTarget).attr('class');
-
-      return !commentActionTarget ? false : commentActionTarget.includes(publicCommentClass);
-    }
     isTargetHost(host) {
       return this.config.hosts.includes(host);
-    }
-    isIncludeTargetWord(text, host) {
-      let commonTargetWords = this.config.targetWords.common;
-      let targetWords       = this.config.targetWords[host];
-
-      let allTargetWords = Array.isArray(targetWords) ? commonTargetWords.concat(targetWords) : commonTargetWords;
-
-      return allTargetWords.some(word => text.includes(word));
-    }
-    createConfirmText(text) {
-      let prefix = '以下の文章はパブリック返信にふさわしくないキーワードが含まれているおそれがあります。\n\n';
-      let suffix = '\n\n本当に送信しますか？';
-
-      let rawText = $(text).text();
-
-      return prefix + rawText + suffix;
     }
   }
 

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -129,6 +129,12 @@
     isTargetHost(host) {
       return this.config.hosts.includes(host);
     }
+    toTargetWords(host) {
+      const commonTargetWords = this.config.targetWords.common;
+      const targetWords       = this.config.targetWords[host];
+
+      return Array.isArray(targetWords) ? commonTargetWords.concat(targetWords) : commonTargetWords;
+    }
   }
 
   class NGWordValidator {

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -131,6 +131,45 @@
     }
   }
 
+  class NGWordValidator {
+    constructor(targetDOM, targetWords) {
+      this.targetDOM   = targetDOM;
+      this.targetWords = targetWords;
+    }
+
+    static get UI_CONSTANTS() {
+      return {
+        selector: {
+          commentActionTarget: 'div.comment_input_wrapper div.fr-focus div.content div.header span.active',
+          commentTextArea: 'div.comment_input_wrapper div.fr-focus div.content div.body div.ember-view div.editor div.zendesk-editor--rich-text-comment'
+        },
+        attribute: {
+          publicCommentClass: 'track-id-publicComment'
+        }
+      };
+    }
+
+    isPublicResponse() {
+      let publicCommentClass  = NGWordValidator.UI_CONSTANTS.attribute.publicCommentClass;
+      let commentActionTarget = $(NGWordValidator.UI_CONSTANTS.selector.commentActionTarget).attr('class');
+
+      return !commentActionTarget ? false : commentActionTarget.includes(publicCommentClass);
+    }
+
+    isIncludeTargetWord(text) {
+      return this.targetWords.some(word => text.includes(word));
+    }
+
+    createConfirmText(text) {
+      let prefix = '以下の文章はパブリック返信にふさわしくないキーワードが含まれているおそれがあります。\n\n';
+      let suffix = '\n\n本当に送信しますか？';
+
+      let rawText = $(text).text();
+
+      return prefix + rawText + suffix;
+    }
+  }
+
   // execute UserScript on browser, and export NGWordManager class on test
   if (typeof window === 'object') {
     const localStorageKey = 'zendeskIncidentProtectorConfigURL';
@@ -166,7 +205,8 @@
   } else {
     module.exports = {
       ValidatorManager: ValidatorManager,
-      NGWordManager: NGWordManager
+      NGWordManager: NGWordManager,
+      NGWordValidator: NGWordValidator
     };
   }
 })();

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -73,6 +73,8 @@
 
         let validator = new NGWordValidator(`${ValidatorManager.UI_CONSTANTS.selector.submitButton}:visible`, targetWords);
         validator.run();
+
+        return validator;
       }
     }
 


### PR DESCRIPTION
送信ボタンのクリックイベント発火時に、入力フォームのテキスト内容をチェックして、必要であればアラートを表示する `NGWordValidator` クラスを実装しました。

これを利用して、 `ValidatorManager#addValidator` を実行した際にインスタンスを生成して入力フォームのチェックを行うようにします。

`NGWordManager` に入っていたメソッドで、入力フォームのチェックに必要なメソッドは `NGWordValidator` に移動しています。（ 6e96274 / 6846ad5 が該当するコミットです)