### PR TITLE
Validatorを開始するタイミングを修正

### DIFF
--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -173,21 +173,17 @@ describe('NGWordManager', () => {
     });
   });
 
-  describe('#setConfigURL', () => {
+  describe('#set configURL', () => {
     context('arg is URL', () => {
       it('should set arg to localStorage', () => {
-        let arg = configURL;
-
-        ngWordManager.setConfigURL(arg);
-        window.localStorage.getItem(localStorageKey).should.equal(arg);
+        ngWordManager.configURL = configURL;
+        window.localStorage.getItem(localStorageKey).should.equal(configURL);
       });
     });
 
     context('arg is not URL', () => {
       it('does not set localStorage', () => {
-        let arg = 'not url';
-
-        ngWordManager.setConfigURL(arg);
+        ngWordManager.configURL = 'not url';
         should.equal(window.localStorage.getItem(localStorageKey), null);
       });
     });
@@ -209,7 +205,7 @@ describe('NGWordManager', () => {
 
   describe('fetchConfig', () => {
     beforeEach(() => {
-      ngWordManager.setConfigURL(configURL);
+      ngWordManager.configURL = configURL;
     });
 
     context('GET config has been successfully finished', () => {

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -344,7 +344,7 @@ describe('NGWordValidator', () => {
   });
 
   describe('createConfirmText', () => {
-    let text = $(NGWordValidator.UI_CONSTANTS.selector.commentTextArea).html();
+    let text = $(NGWordValidator.UI_CONSTANTS.selector.commentTextArea).text();
     let expectedText = 'testmessage';
 
     it('returns confirm text', () => {

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -126,6 +126,10 @@
       }
     }
     fetchConfig() {
+      if (this.config !== undefined) {
+        return Promise.resolve(this.config);
+      }
+
       return new Promise((resolve, reject) => {
         this.request
           .get(this.configURL)
@@ -255,6 +259,22 @@
     if (!ngWordManager.isConfigURLEmpty()) {
       startValidation(ngWordManager, validatorManager);
     }
+
+    // override history.pushState
+    // in order to hook startValidation when history.pushState called
+    (function(history) {
+      let pushState = history.pushState;
+
+      history.pushState = function(state) {
+        // path is set in third argument of history.pushState
+        // ref. https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
+        const path = arguments[2];
+
+        startValidation(ngWordManager, validatorManager);
+
+        return pushState.apply(history, arguments);
+      };
+    })(window.history);
   } else {
     module.exports = {
       ValidatorManager: ValidatorManager,

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -202,9 +202,7 @@
       let prefix = '以下の文章はパブリック返信にふさわしくないキーワードが含まれているおそれがあります。\n\n';
       let suffix = '\n\n本当に送信しますか？';
 
-      let rawText = $(text).text();
-
-      return prefix + rawText + suffix;
+      return prefix + text + suffix;
     }
   }
 

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -222,33 +222,37 @@
 
         ngWordManager.setConfigURL(configURL);
       } else {
-        ngWordManager.fetchConfig()
-          .then(
-            (object) => {
-              ngWordManager.config = object;
-
-              if (ngWordManager.isTargetHost(host)) {
-                return waitForElement(ValidatorManager.UI_CONSTANTS.selector.submitButton);
-              } else {
-                return Promise.reject(new NotTargetHost());
-              }
-            }
-          ).then(
-            (object) => {
-              console.log('submit button loaded!');
-
-              const targetWords = ngWordManager.toTargetWords(host);
-              validatorManager.addValidator(targetWords);
-            }
-          )
-          .catch((error) => {
-            if (error instanceof NotTargetHost) {
-              console.log('This zendesk instance is not target host for validation.');
-            } else {
-              alert(error.message);
-            }
-          });
+        startValidation(ngWordManager, validatorManager);
       }
+    };
+
+    let startValidation = (ngWordManager, validatorManager) => {
+      ngWordManager.fetchConfig()
+        .then(
+          (object) => {
+            ngWordManager.config = object;
+
+            if (ngWordManager.isTargetHost(host)) {
+              return waitForElement(ValidatorManager.UI_CONSTANTS.selector.submitButton);
+            } else {
+              return Promise.reject(new NotTargetHost());
+            }
+          }
+        ).then(
+          (object) => {
+            console.log('submit button loaded!');
+
+            const targetWords = ngWordManager.toTargetWords(host);
+            validatorManager.addValidator(targetWords);
+          }
+        )
+        .catch((error) => {
+          if (error instanceof NotTargetHost) {
+            console.log('This zendesk instance is not target host for validation.');
+          } else {
+            alert(error.message);
+          }
+        });
     };
 
     runUserScript();

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -43,6 +43,12 @@
     });
   }
 
+  class NotTargetHost extends Error {
+    constructor(message) {
+      super(message);
+    }
+  }
+
   // NOTE:
   // Zendesk dashboard can show multiple tickets by separating tabs.
   // This class manages whether to set validator or not with each tabs
@@ -221,7 +227,11 @@
             (object) => {
               ngWordManager.config = object;
 
-              return waitForElement(ValidatorManager.UI_CONSTANTS.selector.submitButton);
+              if (ngWordManager.isTargetHost(host)) {
+                return waitForElement(ValidatorManager.UI_CONSTANTS.selector.submitButton);
+              } else {
+                return Promise.reject(new NotTargetHost());
+              }
             }
           ).then(
             (object) => {
@@ -230,9 +240,14 @@
               const targetWords = ngWordManager.toTargetWords(host);
               validatorManager.addValidator(targetWords);
             }
-          ).catch(
-            (error) => { alert(error.message); }
-          );
+          )
+          .catch((error) => {
+            if (error instanceof NotTargetHost) {
+              console.log('This zendesk instance is not target host for validation.');
+            } else {
+              alert(error.message);
+            }
+          });
       }
     };
 

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -217,18 +217,6 @@
     let ngWordManager    = new NGWordManager(localStorageKey);
     let validatorManager = new ValidatorManager();
 
-    let runUserScript = () => {
-      if (ngWordManager.isConfigURLEmpty()) {
-        let configURL = window.prompt('[Zendesk 事故防止ツール]\nNGワードの設定が記載されたURLを指定してください', '');
-
-        ngWordManager.configURL = configURL;
-      }
-
-      if (!ngWordManager.isConfigURLEmpty()) {
-        startValidation(ngWordManager, validatorManager);
-      }
-    };
-
     let startValidation = (ngWordManager, validatorManager) => {
       ngWordManager.fetchConfig()
         .then(
@@ -258,7 +246,15 @@
         });
     };
 
-    runUserScript();
+    if (ngWordManager.isConfigURLEmpty()) {
+      let configURL = window.prompt('[Zendesk 事故防止ツール]\nNGワードの設定が記載されたURLを指定してください', '');
+
+      ngWordManager.configURL = configURL;
+    }
+
+    if (!ngWordManager.isConfigURLEmpty()) {
+      startValidation(ngWordManager, validatorManager);
+    }
   } else {
     module.exports = {
       ValidatorManager: ValidatorManager,

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -103,15 +103,20 @@
       this._config = arg;
     }
 
-    isConfigURLEmpty() {
-      let configURL = localStorage.getItem(this.localStorageKey);
-      return configURL === null;
+    get configURL() {
+      return localStorage.getItem(this.localStorageKey);
     }
-    setConfigURL(arg) {
+
+    set configURL(arg) {
       if (this.isValidConfigURL(arg)) {
         localStorage.setItem(this.localStorageKey, arg);
       }
     }
+
+    isConfigURLEmpty() {
+      return this.configURL === null;
+    }
+
     isValidConfigURL(arg) {
       try {
         let url = new URL(arg);
@@ -121,11 +126,9 @@
       }
     }
     fetchConfig() {
-      let configURL = localStorage.getItem(this.localStorageKey);
-
       return new Promise((resolve, reject) => {
         this.request
-          .get(configURL)
+          .get(this.configURL)
           .then(function(response) {
             resolve(response.body);
           })

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -215,13 +215,18 @@
 
   // execute UserScript on browser, and export NGWordManager class on test
   if (typeof window === 'object') {
-    const localStorageKey = 'zendeskIncidentProtectorConfigURL';
-    const host            = location.host;
+    const localStorageKey  = 'zendeskIncidentProtectorConfigURL';
+    const host             = location.host;
+    const targetPathRegExp = /agent\/tickets/;
 
     let ngWordManager    = new NGWordManager(localStorageKey);
     let validatorManager = new ValidatorManager();
 
-    let startValidation = (ngWordManager, validatorManager) => {
+    let startValidation = (ngWordManager, validatorManager, path) => {
+      if (!targetPathRegExp.test(path)) {
+        return;
+      }
+
       ngWordManager.fetchConfig()
         .then(
           (object) => {
@@ -257,7 +262,7 @@
     }
 
     if (!ngWordManager.isConfigURLEmpty()) {
-      startValidation(ngWordManager, validatorManager);
+      startValidation(ngWordManager, validatorManager, location.href);
     }
 
     // override history.pushState
@@ -270,7 +275,7 @@
         // ref. https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
         const path = arguments[2];
 
-        startValidation(ngWordManager, validatorManager);
+        startValidation(ngWordManager, validatorManager, path);
 
         return pushState.apply(history, arguments);
       };

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -221,8 +221,10 @@
       if (ngWordManager.isConfigURLEmpty()) {
         let configURL = window.prompt('[Zendesk 事故防止ツール]\nNGワードの設定が記載されたURLを指定してください', '');
 
-        ngWordManager.setConfigURL(configURL);
-      } else {
+        ngWordManager.configURL = configURL;
+      }
+
+      if (!ngWordManager.isConfigURLEmpty()) {
         startValidation(ngWordManager, validatorManager);
       }
     };


### PR DESCRIPTION
これまでは `window.load` 時に、無条件でconfigを取得し、validatorをセットしていたのですがそれを下記の条件にマッチする時に変更します。

* pathが `agent/tickets` を含む場合に処理を開始
* `NGWordManager.config` にconfigがセットされていない場合にconfigを取得
* validatorをセットするタイミングを追加 / 変更
  * configに記載されたhostの場合のみに限定
  * `window.prompt` でconfigのURLをセットした直後も追加
  * `history.pushState` のタイミングでurlが切り替わった場合を追加

---

下記それぞれcommitの説明となります。

* 57b2e06f55461ad7610f240f0fccb8a0cc7ca065 : configに定義された `targetHost` に含まれないhostの場合には、 `validatorManager.addValidator` でvalidatorを追加しない
* 98bf9d252dc7f400bd02b9c8144b3307026280ab : Promiseの一連の処理を `startValidation` に切り出し
* a2c0a5f95155c945f949e006e7018392fbacd767 : `NGWordValidator.createConfirmText` のバグ修正（入力テキストが表示されていなかった不具合修正）
* c77358312eb34c22dd27b19bd7517479a17314fc : `NGWordManager` の `configURL` を getter/setter経由に変更
* 185883bf89e6bd3562e722dcd5861fc2dd15f5a6 : `window.prompt` でconfigのURLをセットした直後にもvalidatorを追加するように
* 657c959c4dca0129cba6423ec613156908e8bb9e : `runUserScript` のメソッドが1度しか呼ばれていなかったので削除（ `history.pushState` の対応のための修正 ）
* e15c9f1b365bcb697c3f78522da4ef3c7d5241ab : `startValidation` を `history.pushState` が呼ばれたタイミングでも呼ぶように
* 20e693129d042880121fe7929168a1f654ea9f72 : pathが `agent/tickets` を含む場合にconfig取得→validator追加の処理を行うように