### PR TITLE
Fix misc

### DIFF
--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -87,8 +87,9 @@ describe('ValidatorManager', () => {
   describe('addValidator', () => {
     it('adds button id into idsWithValidator', () => {
       const targetWords = ['test', 'memo', '(aaa|xxx)'];
+      const buttonId    = expectedButtonId;
 
-      let validator = validatorManager.addValidator(targetWords);
+      let validator = validatorManager.addValidator(targetWords, buttonId);
 
       (validator instanceof NGWordValidator).should.equal(true);
       validatorManager.idsWithValidator.should.contain(expectedButtonId);
@@ -105,7 +106,10 @@ describe('ValidatorManager', () => {
 
     context('after adding validator', () => {
       beforeEach(() => {
-        validatorManager.addValidator();
+        const targetWords = ['test', 'memo', '(aaa|xxx)'];
+        const buttonId    = expectedButtonId;
+
+        validatorManager.addValidator(targetWords, buttonId);
       });
 
       context('with added button id', () => {

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -88,8 +88,9 @@ describe('ValidatorManager', () => {
     it('adds button id into idsWithValidator', () => {
       const targetWords = ['test', 'memo', '(aaa|xxx)'];
       const buttonId    = expectedButtonId;
+      const locale      = 'ja';
 
-      let validator = validatorManager.addValidator(targetWords, buttonId);
+      let validator = validatorManager.addValidator(targetWords, buttonId, locale);
 
       (validator instanceof NGWordValidator).should.equal(true);
       validatorManager.idsWithValidator.should.contain(expectedButtonId);
@@ -131,6 +132,7 @@ describe('ValidatorManager', () => {
 
 describe('NGWordManager', () => {
   const localStorageKey = 'testLocalStorageKey';
+  const locale          = 'ja';
   const configDomain    = 'https://path.to';
   const configPath      = '/config.json';
   const configURL       = configDomain + configPath;
@@ -152,7 +154,7 @@ describe('NGWordManager', () => {
   let ngWordManager;
 
   beforeEach(() => {
-    ngWordManager = new NGWordManager(localStorageKey);
+    ngWordManager = new NGWordManager(localStorageKey, locale);
   });
 
   afterEach(() => {
@@ -234,7 +236,7 @@ describe('NGWordManager', () => {
       });
 
       it('throws error', (done) => {
-        let expectedMessage = '[Zendesk事故防止ツール]\n\n設定ファイルが取得できませんでした。\n継続して発生する場合は開発者にお知らせ下さい。';
+        let expectedMessage = '[Zendesk 事故防止ツール]\n\n設定ファイルが取得できませんでした。\n継続して発生する場合は開発者にお知らせ下さい。';
 
         ngWordManager.fetchConfig()
           .then((object) => {
@@ -297,11 +299,12 @@ describe('NGWordManager', () => {
 describe('NGWordValidator', () => {
   const targetDOM   = ValidatorManager.UI_CONSTANTS.selector.buttonArea;
   const targetWords = ['test', 'memo', '(aaa|xxx)']
+  const locale      = 'ja';
 
   let ngWordValidator;
 
   beforeEach(() => {
-    ngWordValidator = new NGWordValidator(targetDOM, targetWords);
+    ngWordValidator = new NGWordValidator(targetDOM, targetWords, locale);
   });
 
   describe('isPublicResponse', () => {

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -8,11 +8,11 @@ let assert       = require('assert');
 let jsdom        = require('jsdom');
 let should       = chai.should();
 
-let exportedClass = require(path.join(__dirname, '..', 'zendesk-incident-protector.user.js'));
+const exportedClass = require(path.join(__dirname, '..', 'zendesk-incident-protector.user.js'));
 
-let ValidatorManager = exportedClass.ValidatorManager;
-let NGWordManager    = exportedClass.NGWordManager;
-let NGWordValidator  = exportedClass.NGWordValidator;
+const ValidatorManager = exportedClass.ValidatorManager;
+const NGWordManager    = exportedClass.NGWordManager;
+const NGWordValidator  = exportedClass.NGWordValidator;
 
 const { JSDOM } = jsdom;
 const defaultDOM = new JSDOM(`
@@ -100,7 +100,7 @@ describe('ValidatorManager', () => {
   describe('hasValidator', () => {
     context('before adding validator', () => {
       it('returns false', () => {
-        let buttonId = expectedButtonId;
+        const buttonId = expectedButtonId;
         validatorManager.hasValidator(buttonId).should.equal(false);
       });
     });
@@ -115,14 +115,14 @@ describe('ValidatorManager', () => {
 
       context('with added button id', () => {
         it('returns true', () => {
-          let buttonId = expectedButtonId;
+          const buttonId = expectedButtonId;
           validatorManager.hasValidator(buttonId).should.equal(true);
         });
       });
 
       context('with not added button id', () => {
         it('returns false', () => {
-          let buttonId = 'unknown';
+          const buttonId = 'unknown';
           validatorManager.hasValidator(buttonId).should.equal(false);
         });
       });
@@ -236,7 +236,7 @@ describe('NGWordManager', () => {
       });
 
       it('throws error', (done) => {
-        let expectedMessage = '[Zendesk 事故防止ツール]\n\n設定ファイルが取得できませんでした。\n継続して発生する場合は開発者にお知らせ下さい。';
+        const expectedMessage = '[Zendesk 事故防止ツール]\n\n設定ファイルが取得できませんでした。\n継続して発生する場合は開発者にお知らせ下さい。';
 
         ngWordManager.fetchConfig()
           .then((object) => {
@@ -255,8 +255,8 @@ describe('NGWordManager', () => {
 
       context('target words at host is defined', () => {
         it('returns target words defined on common and host', () => {
-          let host = 'aaa.zendesk.com';
-          let expected = ['test', 'memo', '(aaa|xxx)'];
+          const host = 'aaa.zendesk.com';
+          const expected = ['test', 'memo', '(aaa|xxx)'];
 
           ngWordManager.toTargetWords(host).should.eql(expected);
         });
@@ -264,8 +264,8 @@ describe('NGWordManager', () => {
 
       context('target words at host is not defined', () => {
         it('returns target words defined on common', () => {
-          let host = 'ddd.zendesk.com';
-          let expected = ['test', 'memo'];
+          const host = 'ddd.zendesk.com';
+          const expected = ['test', 'memo'];
 
           ngWordManager.toTargetWords(host).should.eql(expected);
         });
@@ -279,7 +279,7 @@ describe('NGWordManager', () => {
     });
 
     context('host defined in config', () => {
-      let host = 'aaa.zendesk.com';
+      const host = 'aaa.zendesk.com';
 
       it('returns true', () => {
         ngWordManager.isTargetHost(host).should.equal(true);
@@ -287,7 +287,7 @@ describe('NGWordManager', () => {
     });
 
     context('host not defined in config', () => {
-      let host = 'unknown.zendesk.com';
+      const host = 'unknown.zendesk.com';
 
       it('returns false', () => {
         ngWordManager.isTargetHost(host).should.equal(false);
@@ -333,11 +333,11 @@ describe('NGWordValidator', () => {
 
   describe('isIncludeTargetWord', () => {
     // text with word in common target words
-    let text1 = 'test hogehoge';
+    const text1 = 'test hogehoge';
     // text with word in target words of aaa.zendesk.com
-    let text2 = '(aaa|xxx) hogehoge';
+    const text2 = '(aaa|xxx) hogehoge';
     // text without target words
-    let text3 = 'aaa hogehoge';
+    const text3 = 'aaa hogehoge';
 
     it('judges target words', () => {
       ngWordValidator.isIncludeTargetWord(text1).should.equal(true);
@@ -347,11 +347,11 @@ describe('NGWordValidator', () => {
   });
 
   describe('createConfirmText', () => {
-    let text = $(NGWordValidator.UI_CONSTANTS.selector.commentTextArea).text();
-    let expectedText = 'testmessage';
+    const text = $(NGWordValidator.UI_CONSTANTS.selector.commentTextArea).text();
+    const expectedText = 'testmessage';
 
     it('returns confirm text', () => {
-      let confirmText = ngWordValidator.createConfirmText(text);
+      const confirmText = ngWordValidator.createConfirmText(text);
 
       confirmText.includes(expectedText).should.equal(true);
     });

--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -75,7 +75,7 @@ describe('ValidatorManager', () => {
     // NOTE:
     // mock $.fn.filter, because :visible is not supported in jsdom
     // ref. https://github.com/tmpvar/jsdom/issues/1048
-    stub.returns($(ValidatorManager.UI_CONSTANTS.selector.submitButton));
+    stub.returns($(ValidatorManager.UI_CONSTANTS.selector.buttonArea));
   });
 
   describe('getButtonId', () => {
@@ -291,7 +291,7 @@ describe('NGWordManager', () => {
 });
 
 describe('NGWordValidator', () => {
-  const targetDOM   = ValidatorManager.UI_CONSTANTS.selector.submitButton;
+  const targetDOM   = ValidatorManager.UI_CONSTANTS.selector.buttonArea;
   const targetWords = ['test', 'memo', '(aaa|xxx)']
 
   let ngWordValidator;

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -61,9 +61,16 @@
     static get UI_CONSTANTS() {
       return {
         selector: {
+          sectionPanel: 'section.main_panes:not([style*="display:none"]):not([style*="display: none"])',
           buttonArea: 'footer.ticket-resolution-footer div.ticket-resolution-footer-pane div.ticket_submit_buttons'
         }
       };
+    }
+
+    targetButtonAreaSelector() {
+      const idFilter = this.idsWithValidator.map(id => `:not([id='${id}'])`).join("");
+
+      return `${ValidatorManager.UI_CONSTANTS.selector.sectionPanel} ${ValidatorManager.UI_CONSTANTS.selector.buttonArea}${idFilter}`;
     }
 
     getButtonId() {
@@ -74,9 +81,10 @@
     addValidator(targetWords, buttonId) {
       if (buttonId !== undefined && !this.hasValidator(buttonId)) {
         this.idsWithValidator.push(buttonId);
+
         console.log(`button id added. id:${buttonId} idsWithValidator:${this.idsWithValidator}`);
 
-        let validator = new NGWordValidator(`${ValidatorManager.UI_CONSTANTS.selector.buttonArea}:visible`, targetWords);
+        let validator = new NGWordValidator(`${ValidatorManager.UI_CONSTANTS.selector.buttonArea}[id='${buttonId}'] button`, targetWords);
         validator.run();
 
         return validator;
@@ -232,7 +240,7 @@
             ngWordManager.config = object;
 
             if (ngWordManager.isTargetHost(host)) {
-              return waitForElement(ValidatorManager.UI_CONSTANTS.selector.submitButton);
+              return waitForElement(validatorManager.targetButtonAreaSelector());
             } else {
               return Promise.reject(new NotTargetHost());
             }
@@ -250,6 +258,8 @@
         .catch((error) => {
           if (error instanceof NotTargetHost) {
             console.log('This zendesk instance is not target host for validation.');
+          } else if (error.message.match(/Not found element/)) {
+            console.log('element of validatorManager.targetButtonAreaSelector does not found.');
           } else {
             alert(error.message);
           }

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -127,7 +127,7 @@
 
     isValidConfigURL(arg) {
       try {
-        let url = new URL(arg);
+        const url = new URL(arg);
         return true;
       } catch (e) {
         return false;
@@ -203,13 +203,13 @@
       let preventEvent = true;
 
       $(that.targetDOM).on('click', function(event) {
-        let text = $(NGWordValidator.UI_CONSTANTS.selector.commentTextArea).text();
+        const text = $(NGWordValidator.UI_CONSTANTS.selector.commentTextArea).text();
 
         if (that.isPublicResponse() && that.isIncludeTargetWord(text) && preventEvent) {
           event.preventDefault();
           event.stopPropagation();
 
-          let confirmText = that.createConfirmText(text);
+          const confirmText = that.createConfirmText(text);
 
           if (!confirm(confirmText)) {
             return false;
@@ -223,8 +223,8 @@
     }
 
     isPublicResponse() {
-      let publicCommentClass  = NGWordValidator.UI_CONSTANTS.attribute.publicCommentClass;
-      let commentActionTarget = $(NGWordValidator.UI_CONSTANTS.selector.commentActionTarget).attr('class');
+      const publicCommentClass  = NGWordValidator.UI_CONSTANTS.attribute.publicCommentClass;
+      const commentActionTarget = $(NGWordValidator.UI_CONSTANTS.selector.commentActionTarget).attr('class');
 
       return !commentActionTarget ? false : commentActionTarget.includes(publicCommentClass);
     }
@@ -234,8 +234,8 @@
     }
 
     createConfirmText(text) {
-      let prefix = NGWordValidator.CONFIRM_TEXT.prefix[this.locale];
-      let suffix = NGWordValidator.CONFIRM_TEXT.suffix[this.locale];
+      const prefix = NGWordValidator.CONFIRM_TEXT.prefix[this.locale];
+      const suffix = NGWordValidator.CONFIRM_TEXT.suffix[this.locale];
 
       return prefix + text + suffix;
     }

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -71,8 +71,7 @@
       return submitButton.attr('id');
     }
 
-    addValidator(targetWords) {
-      let buttonId = this.getButtonId();
+    addValidator(targetWords, buttonId) {
       if (buttonId !== undefined && !this.hasValidator(buttonId)) {
         this.idsWithValidator.push(buttonId);
         console.log(`button id added. id:${buttonId} idsWithValidator:${this.idsWithValidator}`);
@@ -243,7 +242,9 @@
             console.log('submit button loaded!');
 
             const targetWords = ngWordManager.toTargetWords(host);
-            validatorManager.addValidator(targetWords);
+            const buttonId    = $(object).attr('id');
+
+            validatorManager.addValidator(targetWords, buttonId);
           }
         )
         .catch((error) => {

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -193,7 +193,7 @@
         },
         suffix: {
           'ja': '\n\n本当に送信しますか？',
-          'en': '\n\nARE YOU REALLY SEND THIS TO CUSTOMER?'
+          'en': '\n\nDO YOU REALLY SEND THIS TO CUSTOMER?'
         }
       }
     }

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -61,14 +61,14 @@
     static get UI_CONSTANTS() {
       return {
         selector: {
-          submitButton: 'footer.ticket-resolution-footer div.ticket-resolution-footer-pane div.ticket_submit_buttons button'
+          buttonArea: 'footer.ticket-resolution-footer div.ticket-resolution-footer-pane div.ticket_submit_buttons'
         }
       };
     }
 
     getButtonId() {
-      let submitButton = $(ValidatorManager.UI_CONSTANTS.selector.submitButton).filter(':visible');
-      return submitButton.parent().attr('id');
+      let submitButton = $(ValidatorManager.UI_CONSTANTS.selector.buttonArea).filter(':visible');
+      return submitButton.attr('id');
     }
 
     addValidator(targetWords) {
@@ -77,7 +77,7 @@
         this.idsWithValidator.push(buttonId);
         console.log(`button id added. id:${buttonId} idsWithValidator:${this.idsWithValidator}`);
 
-        let validator = new NGWordValidator(`${ValidatorManager.UI_CONSTANTS.selector.submitButton}:visible`, targetWords);
+        let validator = new NGWordValidator(`${ValidatorManager.UI_CONSTANTS.selector.buttonArea}:visible`, targetWords);
         validator.run();
 
         return validator;


### PR DESCRIPTION
諸々細かい部分を修正しました。

* 8b66b41 : `ValidatorManager.UI_CONSTANTS` の内容を修正（この後の 3d36bb9, ab19f5d のための修正です）
* 3d36bb9 : `ValidatorManager.addValidator` 時に `buttonId` を指定して渡すように
* ab19f5d : history.pushStateが呼び出されタブが切り替わった時に適切にValidatorが追加されない問題を修正しました。具体的には下記のような実装に修正しています。
  * `waitForElement` で待ち受ける要素のselectorを、「visible」かつ、「idsWithValidatorにセットされていないidを持つdiv」という条件に変更しました。
  * これにより、「タブを何度か切り替えて、全てのタブの送信ボタンにValidatorがセットされた後」は必ず `waitForElement` で対象の要素が見つからない状態になるため、Errorが出た際のhandlingを `console.log` で出力するだけにとどめています。
* ce0332a : localesを追加し`ja / en` を切替可能にしました。
* 1058860 : 不変な変数について `let` -> `const` に置き換えました。